### PR TITLE
Adds labels taken from enroll key

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ or `service start osqueryd`
 
 ## Enrolling osquery endpoints
 The osquery endpoints will reach out to the TLS server and send a POST to `/api/enroll`
-with a `node_secret` value that it read from it's own filesystem (`/etc/osquery/osquery.secret`
+with a `enroll_secret` value that it read from it's own filesystem (`/etc/osquery/osquery.secret`
 if you followed the `osquery.flags` file above). The value in that file must match
 the node secret being used by the TLS server. The TLS server takes this value from an
 environment variable named NODE_ENROLL_SECRET. If you have not set that variable
@@ -75,6 +75,17 @@ then it defaults to "valid_test".
 
 If the server sends a valid node_secret then it will receive a node key that it
 can use to pull its configuration from the server.
+
+You can also store extra information about the osquery endpoints by adding
+a host identifier and a group label to the front of the enroll secret stored in `/etc/osquery/osquery.secret`.
+The values are separated by a colon.
+
+### Example osquery.secret
+
+`www-1:web:bigrandomstringofcharactersforthewin`
+
+That will label the endpoint with an identifier of `www-1` and a group label of
+`web`
 
 ## Serving configuration files
 The `osquery_configs` folder holds all the configuration files you want to send

--- a/db/migrate/20150817205345_add_columns_to_endpoints.rb
+++ b/db/migrate/20150817205345_add_columns_to_endpoints.rb
@@ -1,0 +1,6 @@
+class AddColumnsToEndpoints < ActiveRecord::Migration
+  def change
+    add_column :endpoints, :identifier, :string
+    add_column :endpoints, :group_label, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150817123135) do
+ActiveRecord::Schema.define(version: 20150817205345) do
 
   create_table "endpoints", force: :cascade do |t|
     t.string   "node_key",         null: false
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 20150817123135) do
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
     t.datetime "last_config_time"
+    t.string   "identifier"
+    t.string   "group_label"
   end
 
   add_index "endpoints", ["node_key"], name: "index_endpoints_on_node_key"

--- a/server.rb
+++ b/server.rb
@@ -22,17 +22,22 @@ class Endpoint < ActiveRecord::Base
   # config_count, integer
   # last_config_time, datetime
   # last_ip, string
+  # identifier, string
+  # group_label, string
   # default ruby timestamps
 
   def self.enroll(in_key, params)
+    enroll_secret, group_label, identifier = in_key.split(':').reverse
     logdebug "received enroll_secret " + in_key
+    logdebug "extrapolated enroll_secret " + enroll_secret
 
-    if in_key != NODE_ENROLL_SECRET
+    if enroll_secret != NODE_ENROLL_SECRET
       logdebug "invalid enroll_secret. Returning MissingEndpoint"
       MissingEndpoint.new
     else
-      logdebug "valid enroll_secret. Creating new endpoint"
-      params.merge! node_key: SecureRandom.uuid, config_count: 0
+      params.merge! node_key: SecureRandom.uuid, config_count: 0,
+        identifier: identifier, group_label: group_label
+      logdebug "valid enroll_secret. Creating new endpoint - #{params}"
       Endpoint.create params
     end
   end
@@ -63,7 +68,8 @@ end
 
 class MissingEndpoint
   attr_accessor :node_key, :config_count, :last_version,
-    :last_config_time, :last_ip, :created_at, :updated_at
+    :last_config_time, :last_ip, :created_at, :updated_at,
+    :identifier, :group_label
 
   def initialize
     @node_key = "missing endpoint"
@@ -73,6 +79,8 @@ class MissingEndpoint
     @last_ip = "missing endpoint"
     @created_at = Time.now
     @updated_at = Time.now
+    @identifer = "missing endpoint"
+    @group_label = "missing endpoint"
   end
 
   def valid?

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -70,6 +70,28 @@ describe 'The osquery TLS api' do
     expect(json["node_invalid"]).to eq(true)
   end
 
+  it "records group name and identifier when a node enrolls with a valid enroll secret" do
+    post '/api/enroll', {enroll_secret: "hostname:groupname:valid_test"}
+    expect(last_response).to be_ok
+    json = JSON.parse(last_response.body)
+    expect(json).to have_key("node_key")
+    valid_node_key = json["node_key"]
+    @endpoint = GuaranteedEndpoint.find_by node_key: valid_node_key
+    expect(@endpoint.identifier).to eq("hostname")
+    expect(@endpoint.group_label).to eq("groupname")
+  end
+
+  it "records just the group namewhen a node enrolls with a valid enroll secret" do
+    post '/api/enroll', {enroll_secret: "groupname:valid_test"}
+    expect(last_response).to be_ok
+    json = JSON.parse(last_response.body)
+    expect(json).to have_key("node_key")
+    valid_node_key = json["node_key"]
+    @endpoint = GuaranteedEndpoint.find_by node_key: valid_node_key
+    expect(@endpoint.identifier).to eq(nil)
+    expect(@endpoint.group_label).to eq("groupname")
+  end
+
   it "returns a default configuration with a valid node secret" do
     post '/api/config', node_key: valid_node_key
     expect(last_response).to be_ok

--- a/spec/endpoint_spec.rb
+++ b/spec/endpoint_spec.rb
@@ -18,6 +18,8 @@ describe 'Endpoint instance methods' do
   it {should respond_to(:last_config_time)}
   it {should respond_to(:config)}
   it {should respond_to(:node_secret)}
+  it {should respond_to(:identifier)}
+  it {should respond_to(:group_label)}
 end
 
 describe 'Endpoint class methods' do

--- a/spec/missing_endpoint_spec.rb
+++ b/spec/missing_endpoint_spec.rb
@@ -18,4 +18,6 @@ describe 'MissingEndpoint instance methods' do
   it {should respond_to(:last_config_time)}
   it {should respond_to(:config)}
   it {should respond_to(:node_secret)}
+  it {should respond_to(:identifier)}
+  it {should respond_to(:group_label)}
 end


### PR DESCRIPTION
In response to #13 this pull request will add an identifier and a group label to the Endpoints which will be taken from the enroll string that the client sends. The string will be split on colons and the last item will be the enroll_secret tested for validity.